### PR TITLE
Adjust calendar button size on mobile

### DIFF
--- a/src/components/MatchList.module.css
+++ b/src/components/MatchList.module.css
@@ -259,4 +259,9 @@ body, .container {
     right: 8px;
     margin-top: 0;
   }
+
+  .calendarButton {
+    font-size: 0.7rem;
+    padding: 2px 8px;
+  }
 }


### PR DESCRIPTION
## Summary
- shrink calendar button on mobile to avoid overlapping channel list

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed9ce4a88332834e3d972ff2346f