### PR TITLE
Replace react-select filters with toggle buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.5.0",
     "react-scripts": "5.0.1",
-    "react-select": "^5.10.1",
     "web-vitals": "^2.1.4",
     "xml-stream": "^0.4.5"
   },

--- a/src/components/MatchFilters.js
+++ b/src/components/MatchFilters.js
@@ -1,6 +1,5 @@
 // MatchFilters.js
 import React from 'react';
-import Select from 'react-select';
 import styles from './MatchList.module.css';
 
 const MatchFilters = ({
@@ -10,46 +9,44 @@ const MatchFilters = ({
   setSelectedLeagueOptions,
   selectedChannelOptions,
   setSelectedChannelOptions,
-  showReplays,
-  setShowReplays
 }) => {
-  const customSelectStyles = {
-    container: (provided) => ({ ...provided, width: '100%' }),
-    control: (provided) => ({ ...provided, minHeight: '38px', borderColor: '#ced4da' }),
-    menu: (provided) => ({ ...provided, zIndex: 5 }),
-    valueContainer: (provided) => ({ ...provided, padding: '2px 8px' }),
-    multiValue: (provided) => ({ ...provided, backgroundColor: '#eaf5fc' }),
-    multiValueLabel: (provided) => ({ ...provided, color: '#3498db' }),
-    option: (provided, state) => ({
-      ...provided,
-      color: state.isSelected ? '#FFF' : '#333',
-      backgroundColor: state.isSelected ? provided.backgroundColor : state.isFocused ? '#f0f0f0' : provided.backgroundColor,
-    }),
+  const toggleOption = (option, selected, setter) => {
+    if (selected.includes(option)) {
+      setter(selected.filter(o => o !== option));
+    } else {
+      setter([...selected, option]);
+    }
   };
 
   return (
     <div className={styles.filtersWrapperCompact}>
       <div className={styles.filterSelectContainer}>
         <label className={styles.filterSelectLabel}>Ligi:</label>
-        <Select
-          options={leagueOptions}
-          isMulti
-          value={selectedLeagueOptions}
-          onChange={setSelectedLeagueOptions}
-          placeholder="Wszystkie ligi"
-          styles={customSelectStyles}
-        />
+        <div className={styles.toggleGroup}>
+          {leagueOptions.map(option => (
+            <button
+              key={option}
+              className={`${styles.toggleButton} ${selectedLeagueOptions.includes(option) ? styles.active : ''}`}
+              onClick={() => toggleOption(option, selectedLeagueOptions, setSelectedLeagueOptions)}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
       </div>
       <div className={styles.filterSelectContainer}>
         <label className={styles.filterSelectLabel}>Kanały:</label>
-        <Select
-          options={channelOptions}
-          isMulti
-          value={selectedChannelOptions}
-          onChange={setSelectedChannelOptions}
-          placeholder="Wszystkie kanały"
-          styles={customSelectStyles}
-        />
+        <div className={styles.toggleGroup}>
+          {channelOptions.map(option => (
+            <button
+              key={option}
+              className={`${styles.toggleButton} ${selectedChannelOptions.includes(option) ? styles.active : ''}`}
+              onClick={() => toggleOption(option, selectedChannelOptions, setSelectedChannelOptions)}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/MatchList.js
+++ b/src/components/MatchList.js
@@ -37,8 +37,13 @@ const MatchList = () => {
           });
         });
 
-        setLeagueOptions([...leagues].sort().map(value => ({ value, label: value })));
-        setChannelOptions([...channels].sort().map(value => ({ value, label: value })));
+        const leaguesArray = [...leagues].sort();
+        const channelsArray = [...channels].sort();
+
+        setLeagueOptions(leaguesArray);
+        setChannelOptions(channelsArray);
+        setSelectedLeagueOptions(leaguesArray);
+        setSelectedChannelOptions(channelsArray);
 
       } catch (err) {
         console.error('Fetch error:', err);
@@ -52,8 +57,8 @@ const MatchList = () => {
   }, []);
 
   const filteredDays = useMemo(() => {
-    const selectedLeagues = selectedLeagueOptions.map(opt => opt.value);
-    const selectedChannels = selectedChannelOptions.map(opt => opt.value);
+    const selectedLeagues = selectedLeagueOptions;
+    const selectedChannels = selectedChannelOptions;
 
     return days.map(day => {
       const filteredMatches = day.matches.filter(match => {
@@ -79,8 +84,6 @@ const MatchList = () => {
         setSelectedLeagueOptions={setSelectedLeagueOptions}
         selectedChannelOptions={selectedChannelOptions}
         setSelectedChannelOptions={setSelectedChannelOptions}
-        showReplays={showReplays}
-        setShowReplays={setShowReplays}
       />
 
       {filteredDays.length === 0 ? (

--- a/src/components/MatchList.module.css
+++ b/src/components/MatchList.module.css
@@ -219,6 +219,29 @@ body, .container {
   color: var(--text-color);
 }
 
+.toggleGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.toggleButton {
+  background-color: var(--primary-bg);
+  color: var(--primary-color);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 0.85em;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.toggleButton.active {
+  background-color: var(--primary-color);
+  color: #fff;
+}
+
 .replayFilterCompact {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove react-select dependency
- replace league and channel dropdowns with toggle buttons
- keep selected items in component state and update filters accordingly
- style toggle buttons

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef02af7883328009365fb22d94bd